### PR TITLE
Add missing clone URL for quickstart

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -15,7 +15,7 @@ Quickstart
 * vagrant up
 * vagrant ssh oob-mgmt-server
 * sudo su - cumulus
-* git clone *<URL>*
+* git clone https://github.com/plumbis/dynamic-ansible-inventory
 * cd cldemo-dynamic-ansible-inventory
 * ansible-playbook redis_setup.yml
 * ansible all -m ping -i get_redis_inventory.py


### PR DESCRIPTION
Hi Pete, 
    It looked like the dynamic inventory git clone line was missing it's URL. 
/John H